### PR TITLE
Correct ghc-8.8.3 64bit checksum

### DIFF
--- a/8.8.3/ghc/tools/chocolateyInstall.ps1
+++ b/8.8.3/ghc/tools/chocolateyInstall.ps1
@@ -33,7 +33,7 @@ $tmpFile = Join-Path $binRoot ($tarFile + "~")
 
 Get-ChocolateyWebFile -PackageName $packageName -FileFullPath $tarPath `
     -Url $url -ChecksumType sha256 -Checksum 2a8fb73080ed4335f7a172fe6cf9da1a2faa51fdb72817c50088292f497fc57a `
-    -Url64bit $url64 -ChecksumType64 sha256 -Checksum64 bbae62018f80dd64781fa0c37ef9333ecf3c8c4fe925ec70601a54d1cccaa395
+    -Url64bit $url64 -ChecksumType64 sha256 -Checksum64 e22586762af0911c06e8140f1792e3ca381a3a482a20d67b9054883038b3a422
 Get-ChocolateyUnzip -fileFullPath $tarPath -destination $binRoot
 Get-ChocolateyUnzip -fileFullPath $tmpFile -destination $binRoot
 rm $tmpFile # Clean up temporary file


### PR DESCRIPTION
* @mistuke That was easy to fix :grin: 
* Fix the packahe for ghc-8.8.3, it is failing with:
```
Error - hashes do not match. Actual value was 'E22586762AF0911C06E8140F1792E3CA381A3A482A20D67B9054883038B3A422'.
ERROR: Checksum for 'C:\ProgramData\chocolatey\lib\ghc\tmp\ghcInstall' did not meet 'bbae62018f80dd64781fa0c37ef9333ecf3c8c4fe925ec70601a54d1cccaa395' for checksum type 'sha256'. Consider passing the actual checksums through with --checksum --checksum64 once you validate the checksums are appropriate. A less secure option is to pass --ignore-checksums if necessary.
The install of ghc was NOT successful.
Error while running 'C:\ProgramData\chocolatey\lib\ghc\tools\chocolateyInstall.ps1'.
 See log for details.
```
* https://chocolatey.org/packages/ghc/8.8.3
* i dont have the checksum for 32 bits